### PR TITLE
Optimize mobile menu layout with larger images and smaller buttons

### DIFF
--- a/apps/web/src/pages/Menu/Menu.css
+++ b/apps/web/src/pages/Menu/Menu.css
@@ -87,16 +87,36 @@
     /* Lätt skugga för snyggare presentation */
 }
 
-/* Smal skärm, två kolumner: kvadratiska miniatyrer så listan inte blir för hög */
+/* Smal skärm: anpassad layout med större bilder och mindre knappar */
 @media (max-width: 639px) {
+    .menu-grid {
+        gap: var(--spacing-sm);
+    }
+
+    .menu-item-simple {
+        padding: var(--spacing-sm);
+        border-radius: 12px;
+    }
+
     .menu-item-simple__image-container {
-        aspect-ratio: 1 / 1;
-        max-height: min(38vh, 220px);
+        aspect-ratio: 4 / 5;
+        max-height: none;
+        margin-bottom: var(--spacing-xs);
     }
 
     .menu-item-simple__title {
-        font-size: 0.95rem;
+        font-size: 0.9rem;
         line-height: 1.25;
+    }
+
+    .menu-item-simple__content {
+        margin-bottom: 8px;
+    }
+
+    .menu-item-simple__btn {
+        padding: 6px 8px;
+        font-size: 0.72rem;
+        letter-spacing: 0.02em;
     }
 }
 


### PR DESCRIPTION
This pull request updates the responsive design for the menu on small screens, focusing on improving the appearance and usability of menu items. The main changes are to the layout, image sizing, and button styling for better mobile presentation.

**Responsive design improvements for small screens:**

* Updated `.menu-grid` to use smaller gaps for a more compact layout.
* Modified `.menu-item-simple` to have increased padding and rounded corners, enhancing the card-like appearance.
* Changed `.menu-item-simple__image-container` to use a 4:5 aspect ratio, removed the maximum height constraint, and added spacing below the image for a more balanced look.
* Adjusted `.menu-item-simple__title` font size for better readability on small screens.
* Added spacing below `.menu-item-simple__content` and reduced the padding and font size of `.menu-item-simple__btn` to optimize space and touch targets.