### PR TITLE
Fix delivery time selection and adjust printer order timing

### DIFF
--- a/apps/web/src/pages/Admin/Dashboard/AdminDashboard.tsx
+++ b/apps/web/src/pages/Admin/Dashboard/AdminDashboard.tsx
@@ -15,6 +15,7 @@ import type {
     OrderCreatedRealtimeEvent,
 } from '@shared/types';
 import { parseApiTimestamp } from '@shared/utils/parseApiTimestamp';
+import { isKitchenTicketPrintDue } from '@shared/utils/scheduledTime';
 import '../Admin.css';
 import { requestWakeLock, releaseWakeLock } from '../../../utils/wakeLock';
 import { startAlarm, stopAlarm, setAlarmVolume, AlarmType, getAudioState, unlockAudio, isAlarmActive } from '../../../utils/alarmPlayer';
@@ -645,9 +646,13 @@ export const AdminDashboard: React.FC = () => {
     // Spårar vilka inkommande ordrar som redan skrivits ut (kökslapp) så att
     // pollingen inte skriver ut samma order flera gånger.
     const printedOrderIdsRef = useRef<Set<string>>(new Set());
-    // Vid första laddningen "seedar" vi befintliga inkommande ordrar utan att
-    // skriva ut dem – endast ordrar som kommer in efter detta skrivs ut.
+    // Vid första laddningen "seedar" vi ordrar som redan är inom utskriftsfönstret
+    // (utan att skriva ut) så refresh inte ger dubbletter. Ordrar som ännu inte
+    // nått 30 min före upphämtning lämnas osedade och skrivs ut när tiden är inne.
     const printSeedDoneRef = useRef(false);
+    // Tvingar omkörning av auto-utskrift när utskriftsfönstret öppnas (även om
+    // pendingOrders-listan är oförändrad).
+    const [printTick, setPrintTick] = useState(0);
 
     // Alarm state & settings
     const [activeAlarmOrder, setActiveAlarmOrder] = useState<Order | null>(null);
@@ -745,15 +750,20 @@ export const AdminDashboard: React.FC = () => {
         };
     }, [fetchOrders]);
 
-    // --- Auto-skriv ut kökslapp så fort en ny order dyker upp i "inkommande" ---
+    // --- Auto-skriv ut kökslapp 30 min före planerad upphämtning / äta-här ---
+    // Hemkörning (utan scheduledTime) skrivs ut så fort ordern syns i Inkommande.
     useEffect(() => {
         // Vänta på första hämtningen innan vi gör något.
         if (loadingOrders) return;
 
-        // Första gången: markera nuvarande inkommande ordrar som redan "kända"
-        // så att de inte skrivs ut. Endast ordrar som kommer in efteråt skrivs ut.
+        // Första gången: markera ordrar som redan är "print-due" som hanterade
+        // så att de inte skrivs ut vid refresh. Ordrar längre fram i tiden lämnas.
         if (!printSeedDoneRef.current) {
-            for (const o of pendingOrders) printedOrderIdsRef.current.add(o.id);
+            for (const o of pendingOrders) {
+                if (isKitchenTicketPrintDue(o.scheduledTime)) {
+                    printedOrderIdsRef.current.add(o.id);
+                }
+            }
             printSeedDoneRef.current = true;
             return;
         }
@@ -762,6 +772,7 @@ export const AdminDashboard: React.FC = () => {
 
         for (const order of pendingOrders) {
             if (printedOrderIdsRef.current.has(order.id)) continue;
+            if (!isKitchenTicketPrintDue(order.scheduledTime)) continue;
             // Markera FÖRE await så att nästa polling inte startar en dubbel utskrift.
             printedOrderIdsRef.current.add(order.id);
             printKitchenTicket(order)
@@ -774,7 +785,14 @@ export const AdminDashboard: React.FC = () => {
                     setError('Kunde inte skriva ut kokslapp. Kontrollera skrivaren.');
                 });
         }
-    }, [pendingOrders, loadingOrders]);
+    }, [pendingOrders, loadingOrders, printTick]);
+
+    // Tick every 15s so a same-day order scheduled later still prints at T-30
+    // even if the pending list content has not changed.
+    useEffect(() => {
+        const id = setInterval(() => setPrintTick((n) => n + 1), 15_000);
+        return () => clearInterval(id);
+    }, []);
 
     // --- Screen Wake Lock API Setup ---
     useEffect(() => {

--- a/apps/web/src/pages/Cart/Cart.tsx
+++ b/apps/web/src/pages/Cart/Cart.tsx
@@ -285,7 +285,7 @@ export const Cart: React.FC = () => {
             return;
         }
 
-        if (isClosedNow && !bypassClosedCheck) {
+        if (isClosedNow && !bypassClosedCheck && orderType !== 'delivery') {
             setShowClosedWarningPopup(true);
             return;
         }
@@ -342,16 +342,20 @@ export const Cart: React.FC = () => {
                 return;
             }
 
-            const clock = resolveScheduledClock();
-            const scheduledTime = scheduledDate
-                ? `${scheduledDate}T${clock}:00`
-                : undefined;
+            const isDelivery = orderType === 'delivery';
+            let scheduledTime: string | undefined;
+            if (!isDelivery) {
+                const clock = resolveScheduledClock();
+                scheduledTime = scheduledDate
+                    ? `${scheduledDate}T${clock}:00`
+                    : undefined;
 
-            const hoursCheck = validateScheduledOrderTime(scheduledTime);
-            if (!hoursCheck.valid) {
-                setError(hoursCheck.error);
-                setIsSubmitting(false);
-                return;
+                const hoursCheck = validateScheduledOrderTime(scheduledTime);
+                if (!hoursCheck.valid) {
+                    setError(hoursCheck.error);
+                    setIsSubmitting(false);
+                    return;
+                }
             }
 
             if (paymentChoice === 'swish') {
@@ -372,7 +376,7 @@ export const Cart: React.FC = () => {
                 orderType: orderType as OrderType,
                 customerInfo,
                 deliveryInfo: deliveryInfo,
-                scheduledTime,
+                ...(scheduledTime ? { scheduledTime } : {}),
                 paymentMethod: paymentChoice,
             });
 
@@ -407,7 +411,7 @@ export const Cart: React.FC = () => {
                     <h1 className="text-display-md cart-title">{t('cart.title')}</h1>
                 )}
 
-                {isClosedNow && items.length > 0 && (
+                {isClosedNow && !isDeliveryOrder && items.length > 0 && (
                     <div className="cart-closed-banner animate-in" style={{
                         padding: '1.25rem',
                         background: '#fff9e6',
@@ -682,12 +686,13 @@ export const Cart: React.FC = () => {
                                 size="lg"
                                 className="checkout-btn"
                                 onClick={() => handleCheckout()}
-                                disabled={isSubmitting || !clockRange}
+                                disabled={isSubmitting || (!isDeliveryOrder && !clockRange)}
                             >
                                 {isSubmitting ? 'Skapar beställning...' : t('cart.checkout')}
                             </Button>
                         </div>
 
+                        {!isDeliveryOrder && (
                         <div className="cart-schedule">
                             <h3 className="cart-schedule__title">{t('cart.schedule_title')}</h3>
                             <label htmlFor="cart-schedule-date" className="cart-schedule__label">
@@ -778,6 +783,7 @@ export const Cart: React.FC = () => {
                                 {formatScheduleSummary()}
                             </p>
                         </div>
+                        )}
                     </div>
                 )}
             </Container>

--- a/apps/web/src/services/printer.ts
+++ b/apps/web/src/services/printer.ts
@@ -160,7 +160,7 @@ function finishPrint(xml: string): string {
 }
 
 /**
- * Skriver ut en kökslapp (utan priser) — används vid accept.
+ * Skriver ut en kökslapp (utan priser) — auto vid Inkommande / 30 min före planerad tid.
  */
 export async function printKitchenTicket(order: Order): Promise<{ success: boolean; error?: string }> {
   let xml = '';

--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -126,19 +126,22 @@ router.post('/', async (req: Request, res: Response) => {
       ? Number(settings.default_preparation_time_minutes) || 30
       : 30;
 
+    // Hemkörning has no customer-chosen time (1–2 business days); ignore any scheduledTime.
     let scheduledAt: Date | null = null;
-    if (body.scheduledTime != null && String(body.scheduledTime).trim() !== '') {
-      scheduledAt = parseOrderScheduledAt(body.scheduledTime);
-      if (!scheduledAt || Number.isNaN(scheduledAt.getTime())) {
-        res.status(400).json({ error: 'Ogiltig förbeställningstid. Välj datum och tid igen.' });
+    if (!isDelivery) {
+      if (body.scheduledTime != null && String(body.scheduledTime).trim() !== '') {
+        scheduledAt = parseOrderScheduledAt(body.scheduledTime);
+        if (!scheduledAt || Number.isNaN(scheduledAt.getTime())) {
+          res.status(400).json({ error: 'Ogiltig förbeställningstid. Välj datum och tid igen.' });
+          return;
+        }
+      }
+
+      const hoursValidation = validateScheduledOrderTime(body.scheduledTime, defaultPrep);
+      if (!hoursValidation.valid) {
+        res.status(400).json({ error: hoursValidation.error });
         return;
       }
-    }
-
-    const hoursValidation = validateScheduledOrderTime(body.scheduledTime, defaultPrep);
-    if (!hoursValidation.valid) {
-      res.status(400).json({ error: hoursValidation.error });
-      return;
     }
 
     const baseTime = scheduledAt && scheduledAt.getTime() > Date.now() ? scheduledAt : new Date();

--- a/shared/utils/scheduledTime.ts
+++ b/shared/utils/scheduledTime.ts
@@ -1,6 +1,25 @@
 /** Minimum lead time before the earliest selectable slot (matches default prep time). */
 export const DEFAULT_ORDER_LEAD_MINUTES = 30;
 
+/** How long before scheduled pickup/eat-here time the kitchen ticket should print. */
+export const KITCHEN_TICKET_LEAD_MINUTES = 30;
+
+/**
+ * Whether the kitchen ticket should print now.
+ * - No scheduled time (e.g. delivery): print immediately.
+ * - With scheduled time: print once `scheduledTime - leadMinutes` has passed.
+ */
+export function isKitchenTicketPrintDue(
+  scheduledTime: string | null | undefined,
+  at: Date = new Date(),
+  leadMinutes = KITCHEN_TICKET_LEAD_MINUTES
+): boolean {
+  if (scheduledTime == null || String(scheduledTime).trim() === '') return true;
+  const scheduledMs = new Date(scheduledTime).getTime();
+  if (Number.isNaN(scheduledMs)) return true;
+  return at.getTime() >= scheduledMs - leadMinutes * 60 * 1000;
+}
+
 const STOCKHOLM_TZ = 'Europe/Stockholm';
 
 /** YYYY-MM-DD for a Date in Europe/Stockholm. */


### PR DESCRIPTION
This pull request implements a more accurate and flexible system for auto-printing kitchen tickets, ensuring that orders are only printed at the appropriate time (e.g., 30 minutes before scheduled pickup/eat-here, or immediately for delivery). It also improves order scheduling and validation, especially for delivery orders, and refines the cart UI and logic to match these rules.

**Kitchen Ticket Printing Logic Improvements:**

* Added `isKitchenTicketPrintDue` utility to determine when a kitchen ticket should be printed, based on scheduled time and a configurable lead time (default 30 minutes).
* Updated `AdminDashboard` so that on initial load, only orders that are already within the print window are marked as printed, preventing duplicate prints on refresh. Orders scheduled further in the future will print automatically when their window opens, even if the order list doesn't change. 
* 
* The kitchen ticket print function and its documentation were updated to clarify that tickets are printed automatically either when an order appears (for delivery) or 30 minutes before scheduled time.

**Cart and Order Scheduling Logic:**

* Delivery orders now bypass closed-hour checks and do not require a scheduled time; scheduled time is only set for pickup/eat-here orders. The cart UI and checkout logic have been updated to reflect this, disabling schedule selection for delivery and ensuring proper validation. 

**Backend Order Validation:**

* The backend now ignores any `scheduledTime` for delivery orders, ensuring that only pickup/eat-here orders are validated for scheduled time and opening hours. 